### PR TITLE
fix(apply): handle issue where the first theme added is not populated in the dropdown

### DIFF
--- a/ui.html
+++ b/ui.html
@@ -722,7 +722,7 @@ function switchTab(element, destination) {
 //find list of unique themes in JSON from API
 function populateThemeSelection() {
 
-	if (latestAPIData.length > 1) {
+	if (latestAPIData.length >= 1) {
 
 		selectMenu.destroy();
 	


### PR DESCRIPTION
Adding a theme for the first time will cause an empty dropdown to appear in the apply menu.